### PR TITLE
Set 1 Challenge 3

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -126,7 +126,7 @@ IndentExternBlock: AfterExternBlock
 IndentGotoLabels: true
 IndentPPDirectives: None
 IndentRequiresClause: true
-IndentWidth:     2
+IndentWidth:     4
 IndentWrappedFunctionNames: false
 InsertBraces:    false
 InsertNewlineAtEOF: false

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 # build folder
 build
 compile_commands.json
+.cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,16 +35,24 @@ add_executable(test_01_02_fixed_xor
     src/string_interaction.cpp
     src/01_02_fixed_xor.cpp
     test/test_01_02_fixed_xor.cpp)
+add_executable(test_01_03_single_byte_xor
+    src/string_interaction.cpp
+    src/01_03_single_byte_xor.cpp
+    test/test_01_03_single_byte_xor.cpp)
 
 target_include_directories(test_01_01_hex_to_base64
     PRIVATE ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(test_01_02_fixed_xor
     PRIVATE ${PROJECT_SOURCE_DIR}/include)
+target_include_directories(test_01_03_single_byte_xor
+    PRIVATE ${PROJECT_SOURCE_DIR}/include)
 
 target_link_libraries(test_01_01_hex_to_base64 GTest::gtest_main)
 target_link_libraries(test_01_02_fixed_xor GTest::gtest_main)
+target_link_libraries(test_01_03_single_byte_xor GTest::gtest_main)
 
 include(GoogleTest)
 gtest_discover_tests(test_01_01_hex_to_base64)
 gtest_discover_tests(test_01_02_fixed_xor)
+gtest_discover_tests(test_01_03_single_byte_xor)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ cmake --build build
 cd build && ctest
 ```
 
+## Format
+
+To run `clang-format` on the project files, run the following command:
+```
+find include/ src/ test/ -name *.hpp -o -name *.cpp | xargs clang-format -i
+```
+
 ## Credit
 
 Thanks are in order for Thomas Ptacek, Sean Devlin, Alex Balducci, and Marcin Wielgoszewski for their work on [the cryptopals crypto challenges](https://cryptopals.com/).

--- a/include/01_03_single_byte_xor.hpp
+++ b/include/01_03_single_byte_xor.hpp
@@ -1,0 +1,6 @@
+#ifndef SINGLE_BYTE_XOR_H
+#define SINGLE_BYTE_XOR_H
+
+char single_byte_xor(const std::string& hex_string);
+
+#endif

--- a/include/01_03_single_byte_xor.hpp
+++ b/include/01_03_single_byte_xor.hpp
@@ -1,6 +1,8 @@
 #ifndef SINGLE_BYTE_XOR_H
 #define SINGLE_BYTE_XOR_H
 
+#include <string>
+
 char single_byte_xor(const std::string& hex_string);
 
 #endif

--- a/include/01_03_single_byte_xor.hpp
+++ b/include/01_03_single_byte_xor.hpp
@@ -3,6 +3,6 @@
 
 #include <string>
 
-char single_byte_xor(const std::string& hex_string);
+char single_byte_xor(const std::string& hex_string, std::string& decoded_output);
 
 #endif

--- a/include/string_interaction.hpp
+++ b/include/string_interaction.hpp
@@ -1,17 +1,13 @@
 #ifndef STRING_INTERACTION_H
 #define STRING_INTERACTION_H
 
-#include <cstdint>
 #include <string>
 #include <vector>
 
 enum class status { ok, error };
 
-const uint8_t hex_chars[16] = {'0', '1', '2', '3', '4', '5', '6', '7',
-                               '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+status hex_from_string(const std::string& hex_input, std::vector<char>& byte_output);
 
-status hex_from_string(const std::string& hex_input, std::vector<uint8_t>& byte_input);
-
-status bytes_to_hex_string(const std::vector<uint8_t>& byte_input, std::string& string_output);
+status bytes_to_hex_string(const std::vector<char>& byte_input, std::string& string_output);
 
 #endif

--- a/src/01_01_hex_to_base64.cpp
+++ b/src/01_01_hex_to_base64.cpp
@@ -29,21 +29,21 @@ static const std::string base64_chars =
     "0123456789+/";
 
 void hex_to_base64(const std::string& hex_string, std::string& base64_string) {
-  std::vector<uint8_t> byte_array;
-  std::vector<uint8_t> b64_array;
+    std::vector<uint8_t> byte_array;
+    std::vector<uint8_t> b64_array;
 
-  if (hex_from_string(hex_string, byte_array) == status::error) {
-    return;
-  }
+    if (hex_from_string(hex_string, byte_array) == status::error) {
+        return;
+    }
 
-  for (uint32_t i = 0; i < byte_array.size(); i += 3) {
-    b64_array.push_back((byte_array[i] & 0xfc) >> 2);
-    b64_array.push_back(((byte_array[i] & 0x03) << 4) | ((byte_array[i + 1] & 0xf0) >> 4));
-    b64_array.push_back(((byte_array[i + 1] & 0x0f) << 2) | ((byte_array[i + 2] & 0xc0) >> 6));
-    b64_array.push_back(byte_array[i + 2] & 0x3f);
-  }
+    for (uint32_t i = 0; i < byte_array.size(); i += 3) {
+        b64_array.push_back((byte_array[i] & 0xfc) >> 2);
+        b64_array.push_back(((byte_array[i] & 0x03) << 4) | ((byte_array[i + 1] & 0xf0) >> 4));
+        b64_array.push_back(((byte_array[i + 1] & 0x0f) << 2) | ((byte_array[i + 2] & 0xc0) >> 6));
+        b64_array.push_back(byte_array[i + 2] & 0x3f);
+    }
 
-  for (uint8_t b64_byte : b64_array) {
-    base64_string.push_back(base64_chars[b64_byte]);
-  }
+    for (uint8_t b64_byte : b64_array) {
+        base64_string.push_back(base64_chars[b64_byte]);
+    }
 }

--- a/src/01_01_hex_to_base64.cpp
+++ b/src/01_01_hex_to_base64.cpp
@@ -1,5 +1,6 @@
 #include "01_01_hex_to_base64.hpp"
 
+#include <cstdint>
 #include <cstdlib>
 
 #include "string_interaction.hpp"
@@ -29,7 +30,7 @@ static const std::string base64_chars =
     "0123456789+/";
 
 void hex_to_base64(const std::string& hex_string, std::string& base64_string) {
-    std::vector<uint8_t> byte_array;
+    std::vector<char> byte_array;
     std::vector<uint8_t> b64_array;
 
     if (hex_from_string(hex_string, byte_array) == status::error) {

--- a/src/01_02_fixed_xor.cpp
+++ b/src/01_02_fixed_xor.cpp
@@ -1,7 +1,6 @@
-#include <cstdint>
+#include "01_02_fixed_xor.hpp"
+
 #include <stdexcept>
-#include <string>
-#include <vector>
 
 #include "string_interaction.hpp"
 

--- a/src/01_02_fixed_xor.cpp
+++ b/src/01_02_fixed_xor.cpp
@@ -20,9 +20,9 @@
 
 void fixed_xor(const std::string& hex_string_a, const std::string& hex_string_b,
                std::string& xor_output) {
-    std::vector<uint8_t> byte_array_a;
-    std::vector<uint8_t> byte_array_b;
-    std::vector<uint8_t> xor_byte_array;
+    std::vector<char> byte_array_a;
+    std::vector<char> byte_array_b;
+    std::vector<char> xor_byte_array;
 
     if (hex_string_a.length() != hex_string_b.length()) {
         return;
@@ -36,9 +36,9 @@ void fixed_xor(const std::string& hex_string_a, const std::string& hex_string_b,
         return;
     }
 
-    std::vector<uint8_t>::iterator it_a = byte_array_a.begin();
-    std::vector<uint8_t>::iterator it_b = byte_array_b.begin();
-    uint8_t temp_byte = 0U;
+    std::vector<char>::iterator it_a = byte_array_a.begin();
+    std::vector<char>::iterator it_b = byte_array_b.begin();
+    char temp_byte = 0U;
     while (it_a != byte_array_a.end()) {
         temp_byte = *it_a ^ *it_b;
         xor_byte_array.push_back(temp_byte);

--- a/src/01_02_fixed_xor.cpp
+++ b/src/01_02_fixed_xor.cpp
@@ -20,33 +20,33 @@
 
 void fixed_xor(const std::string& hex_string_a, const std::string& hex_string_b,
                std::string& xor_output) {
-  std::vector<uint8_t> byte_array_a;
-  std::vector<uint8_t> byte_array_b;
-  std::vector<uint8_t> xor_byte_array;
+    std::vector<uint8_t> byte_array_a;
+    std::vector<uint8_t> byte_array_b;
+    std::vector<uint8_t> xor_byte_array;
 
-  if (hex_string_a.length() != hex_string_b.length()) {
-    return;
-  }
+    if (hex_string_a.length() != hex_string_b.length()) {
+        return;
+    }
 
-  if (hex_from_string(hex_string_a, byte_array_a) == status::error) {
-    return;
-  }
+    if (hex_from_string(hex_string_a, byte_array_a) == status::error) {
+        return;
+    }
 
-  if (hex_from_string(hex_string_b, byte_array_b) == status::error) {
-    return;
-  }
+    if (hex_from_string(hex_string_b, byte_array_b) == status::error) {
+        return;
+    }
 
-  std::vector<uint8_t>::iterator it_a = byte_array_a.begin();
-  std::vector<uint8_t>::iterator it_b = byte_array_b.begin();
-  uint8_t temp_byte = 0U;
-  while (it_a != byte_array_a.end()) {
-    temp_byte = *it_a ^ *it_b;
-    xor_byte_array.push_back(temp_byte);
-    it_a++;
-    it_b++;
-  }
+    std::vector<uint8_t>::iterator it_a = byte_array_a.begin();
+    std::vector<uint8_t>::iterator it_b = byte_array_b.begin();
+    uint8_t temp_byte = 0U;
+    while (it_a != byte_array_a.end()) {
+        temp_byte = *it_a ^ *it_b;
+        xor_byte_array.push_back(temp_byte);
+        it_a++;
+        it_b++;
+    }
 
-  if (bytes_to_hex_string(xor_byte_array, xor_output) == status::error) {
-    return;
-  }
+    if (bytes_to_hex_string(xor_byte_array, xor_output) == status::error) {
+        return;
+    }
 }

--- a/src/01_03_single_byte_xor.cpp
+++ b/src/01_03_single_byte_xor.cpp
@@ -1,7 +1,7 @@
 #include "01_03_single_byte_xor.hpp"
 
 #include <cctype>
-#include <iostream>
+#include <cstdint>
 #include <unordered_map>
 
 #include "string_interaction.hpp"
@@ -12,54 +12,50 @@
  * against the message. Devise a method to "score" a piece of English plaintext.
  * Hint indicates character frequency is a good metric. Evaluate each output and
  * choose the one with the best score.
- *
- * Wikipedia (en.wikipedia.org/wiki/Letter_frequency) lists relative frequency
  */
 
 // from http://en.algoritmy.net/article/40379/Letter-frequency-English
-static const std::unordered_map<uint8_t, double> char_freq = {
+static const std::unordered_map<char, double> char_freq = {
     {'a', 8.167}, {'b', 1.492}, {'c', 2.782}, {'d', 4.253}, {'e', 12.702}, {'f', 2.228},
     {'g', 2.015}, {'h', 6.094}, {'i', 6.966}, {'j', 0.153}, {'k', 0.772},  {'l', 4.025},
     {'m', 2.406}, {'n', 6.749}, {'o', 7.507}, {'p', 1.929}, {'q', 0.095},  {'r', 5.987},
     {'s', 6.327}, {'t', 9.056}, {'u', 2.758}, {'v', 0.978}, {'w', 2.360},  {'x', 0.150},
     {'y', 1.974}, {'z', 0.074}};
 
-char single_byte_xor(const std::string& hex_string) {
+char single_byte_xor(const std::string& hex_string, std::string& decoded_output) {
     char key = 0;
-    std::vector<uint8_t> byte_array;
-    std::vector<uint8_t> byte_array_copy;
+    std::vector<char> byte_array;
 
     if (hex_from_string(hex_string, byte_array) == status::error) {
-        std::cout << "hex_from_string error" << '\n';
         return key;
     }
 
-    for (uint8_t& c : byte_array) {
+    for (char& c : byte_array) {
         c = std::tolower(c);
     }
 
     uint32_t max_score = 0;
     uint32_t current_score = 0;
-    for (uint32_t xor_char = 'a'; xor_char <= 'z'; xor_char++) {
-        current_score = 0;
-        byte_array_copy = byte_array;
-        for (uint8_t& c : byte_array_copy) {
-            c = std::tolower(c ^ xor_char);
+    std::vector<char> byte_array_copy = byte_array;
+    for (int32_t xor_char = -128; xor_char <= 127; xor_char++) {
+        for (char& c : byte_array_copy) {
+            c = c ^ xor_char;
             if (c == ' ') current_score += 15;
-            if (c < 'a' || c > 'z') c = ' ';
             if (!std::isalpha(c)) continue;
-            current_score += char_freq.at(c);
+            current_score += char_freq.at(std::tolower(c));
         }
-        std::cout << "string [" << xor_char << "]: ";
-        for (uint8_t c : byte_array_copy) {
-            std::cout << c;
-        }
-        std::cout << "  score: " << current_score << '\n';
         if (current_score > max_score) {
             max_score = current_score;
-            key = static_cast<char>(xor_char);
-            std::cout << "max_score: " << max_score << '\n';
+            key = xor_char;
+            decoded_output.clear();
+            for (const char c : byte_array_copy) {
+                decoded_output.push_back(c);
+            }
         }
+
+        current_score = 0;
+        byte_array_copy.clear();
+        byte_array_copy = byte_array;
     }
     return key;
 }

--- a/src/01_03_single_byte_xor.cpp
+++ b/src/01_03_single_byte_xor.cpp
@@ -1,14 +1,65 @@
 #include "01_03_single_byte_xor.hpp"
 
+#include <cctype>
+#include <iostream>
+#include <unordered_map>
+
 #include "string_interaction.hpp"
 
+/* Set 1 Challenge 3: Single-byte XOR cipher
+ *
+ * Given a hex encoded string, find the single character that has been XOR'd
+ * against the message. Devise a method to "score" a piece of English plaintext.
+ * Hint indicates character frequency is a good metric. Evaluate each output and
+ * choose the one with the best score.
+ *
+ * Wikipedia (en.wikipedia.org/wiki/Letter_frequency) lists relative frequency
+ */
+
+// from http://en.algoritmy.net/article/40379/Letter-frequency-English
+static const std::unordered_map<uint8_t, double> char_freq = {
+    {'a', 8.167}, {'b', 1.492}, {'c', 2.782}, {'d', 4.253}, {'e', 12.702}, {'f', 2.228},
+    {'g', 2.015}, {'h', 6.094}, {'i', 6.966}, {'j', 0.153}, {'k', 0.772},  {'l', 4.025},
+    {'m', 2.406}, {'n', 6.749}, {'o', 7.507}, {'p', 1.929}, {'q', 0.095},  {'r', 5.987},
+    {'s', 6.327}, {'t', 9.056}, {'u', 2.758}, {'v', 0.978}, {'w', 2.360},  {'x', 0.150},
+    {'y', 1.974}, {'z', 0.074}};
+
 char single_byte_xor(const std::string& hex_string) {
-  char key = 0;
-  std::vector<uint8_t> byte_array;
+    char key = 0;
+    std::vector<uint8_t> byte_array;
+    std::vector<uint8_t> byte_array_copy;
 
-  if (hex_from_string(hex_string, byte_array) == status::error) {
+    if (hex_from_string(hex_string, byte_array) == status::error) {
+        std::cout << "hex_from_string error" << '\n';
+        return key;
+    }
+
+    for (uint8_t& c : byte_array) {
+        c = std::tolower(c);
+    }
+
+    uint32_t max_score = 0;
+    uint32_t current_score = 0;
+    for (uint32_t xor_char = 'a'; xor_char <= 'z'; xor_char++) {
+        current_score = 0;
+        byte_array_copy = byte_array;
+        for (uint8_t& c : byte_array_copy) {
+            c = std::tolower(c ^ xor_char);
+            if (c == ' ') current_score += 15;
+            if (c < 'a' || c > 'z') c = ' ';
+            if (!std::isalpha(c)) continue;
+            current_score += char_freq.at(c);
+        }
+        std::cout << "string [" << xor_char << "]: ";
+        for (uint8_t c : byte_array_copy) {
+            std::cout << c;
+        }
+        std::cout << "  score: " << current_score << '\n';
+        if (current_score > max_score) {
+            max_score = current_score;
+            key = static_cast<char>(xor_char);
+            std::cout << "max_score: " << max_score << '\n';
+        }
+    }
     return key;
-  }
-
-  return key;
 }

--- a/src/01_03_single_byte_xor.cpp
+++ b/src/01_03_single_byte_xor.cpp
@@ -1,0 +1,14 @@
+#include "01_03_single_byte_xor.hpp"
+
+#include "string_interaction.hpp"
+
+char single_byte_xor(const std::string& hex_string) {
+  char key = 0;
+  std::vector<uint8_t> byte_array;
+
+  if (hex_from_string(hex_string, byte_array) == status::error) {
+    return key;
+  }
+
+  return key;
+}

--- a/src/string_interaction.cpp
+++ b/src/string_interaction.cpp
@@ -1,21 +1,27 @@
 #include "string_interaction.hpp"
 
-status hex_from_string(const std::string& hex_input, std::vector<uint8_t>& byte_output) {
+#include <array>
+#include <cstdint>
+
+constexpr std::array<char, 16> hex_chars = {'0', '1', '2', '3', '4', '5', '6', '7',
+                                            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+
+status hex_from_string(const std::string& hex_input, std::vector<char>& byte_output) {
     if (hex_input.length() % 2 == 1) {
         return status::error;
     }
 
     for (uint32_t i = 0; i < hex_input.length(); i += 2) {
         std::string byte_string = hex_input.substr(i, 2);
-        uint8_t byte = static_cast<uint8_t>(std::strtoul(byte_string.c_str(), NULL, 16));
+        char byte = static_cast<char>(std::stoi(byte_string, nullptr, 16));
         byte_output.push_back(byte);
     }
 
     return status::ok;
 }
 
-status bytes_to_hex_string(const std::vector<uint8_t>& byte_input, std::string& string_output) {
-    for (uint8_t byte : byte_input) {
+status bytes_to_hex_string(const std::vector<char>& byte_input, std::string& string_output) {
+    for (char byte : byte_input) {
         string_output += hex_chars[(byte & 0xf0) >> 4];
         string_output += hex_chars[(byte & 0x0f)];
     }

--- a/src/string_interaction.cpp
+++ b/src/string_interaction.cpp
@@ -1,24 +1,24 @@
 #include "string_interaction.hpp"
 
 status hex_from_string(const std::string& hex_input, std::vector<uint8_t>& byte_output) {
-  if (hex_input.length() % 2 == 1) {
-    return status::error;
-  }
+    if (hex_input.length() % 2 == 1) {
+        return status::error;
+    }
 
-  for (uint32_t i = 0; i < hex_input.length(); i += 2) {
-    std::string byte_string = hex_input.substr(i, 2);
-    uint8_t byte = static_cast<uint8_t>(std::strtoul(byte_string.c_str(), NULL, 16));
-    byte_output.push_back(byte);
-  }
+    for (uint32_t i = 0; i < hex_input.length(); i += 2) {
+        std::string byte_string = hex_input.substr(i, 2);
+        uint8_t byte = static_cast<uint8_t>(std::strtoul(byte_string.c_str(), NULL, 16));
+        byte_output.push_back(byte);
+    }
 
-  return status::ok;
+    return status::ok;
 }
 
 status bytes_to_hex_string(const std::vector<uint8_t>& byte_input, std::string& string_output) {
-  for (uint8_t byte : byte_input) {
-    string_output += hex_chars[(byte & 0xf0) >> 4];
-    string_output += hex_chars[(byte & 0x0f)];
-  }
+    for (uint8_t byte : byte_input) {
+        string_output += hex_chars[(byte & 0xf0) >> 4];
+        string_output += hex_chars[(byte & 0x0f)];
+    }
 
-  return status::ok;
+    return status::ok;
 }

--- a/test/test_01_01_hex_to_base64.cpp
+++ b/test/test_01_01_hex_to_base64.cpp
@@ -3,16 +3,16 @@
 #include "01_01_hex_to_base64.hpp"
 
 TEST(hex_to_base64, given_example) {
-  const std::string given_input =
-      "49276d206b696c6c696e6720796f7572206272616"
-      "96e206c696b65206120706f69736f6e6f7573206d"
-      "757368726f6f6d";
-  const std::string given_output =
-      "SSdtIGtpbGxpbmcgeW91ciBicmFpbiBsaWtlIGEg"
-      "cG9pc29ub3VzIG11c2hyb29t";
-  std::string converted_output = "";
+    const std::string given_input =
+        "49276d206b696c6c696e6720796f7572206272616"
+        "96e206c696b65206120706f69736f6e6f7573206d"
+        "757368726f6f6d";
+    const std::string given_output =
+        "SSdtIGtpbGxpbmcgeW91ciBicmFpbiBsaWtlIGEg"
+        "cG9pc29ub3VzIG11c2hyb29t";
+    std::string converted_output = "";
 
-  hex_to_base64(given_input, converted_output);
+    hex_to_base64(given_input, converted_output);
 
-  ASSERT_EQ(given_output, converted_output);
+    ASSERT_EQ(given_output, converted_output);
 }

--- a/test/test_01_02_fixed_xor.cpp
+++ b/test/test_01_02_fixed_xor.cpp
@@ -3,12 +3,12 @@
 #include "01_02_fixed_xor.hpp"
 
 TEST(fixed_xor, given_example) {
-  const std::string given_input_a = "1c0111001f010100061a024b53535009181c";
-  const std::string given_input_b = "686974207468652062756c6c277320657965";
-  const std::string given_output = "746865206b696420646f6e277420706c6179";
-  std::string converted_output = "";
+    const std::string given_input_a = "1c0111001f010100061a024b53535009181c";
+    const std::string given_input_b = "686974207468652062756c6c277320657965";
+    const std::string given_output = "746865206b696420646f6e277420706c6179";
+    std::string converted_output = "";
 
-  fixed_xor(given_input_a, given_input_b, converted_output);
+    fixed_xor(given_input_a, given_input_b, converted_output);
 
-  ASSERT_EQ(given_output, converted_output);
+    ASSERT_EQ(given_output, converted_output);
 }

--- a/test/test_01_03_single_byte_xor.cpp
+++ b/test/test_01_03_single_byte_xor.cpp
@@ -5,9 +5,12 @@
 TEST(single_byte_xor, given_example) {
     const std::string given_input =
         "1b37373331363f78151b7f2b783431333d78397828372d363c78373e783a393b3736";
-    char given_key = 'x';
+    const std::string given_output = "Cooking MC's like a pound of bacon";
+    const char given_key = 'X';
+    std::string decoded_output = "";
 
-    char scored_key = single_byte_xor(given_input);
+    char scored_key = single_byte_xor(given_input, decoded_output);
 
     ASSERT_EQ(scored_key, given_key);
+    ASSERT_EQ(given_output, decoded_output);
 }

--- a/test/test_01_03_single_byte_xor.cpp
+++ b/test/test_01_03_single_byte_xor.cpp
@@ -1,0 +1,13 @@
+#include <gtest/gtest.h>
+
+#include "01_03_single_byte_xor.hpp"
+
+TEST(single_byte_xor, given_example) {
+  const std::string given_input =
+      "1b37373331363f78151b7f2b783431333d78397828372d363c78373e783a393b3736";
+  char given_key = '0';
+
+  char scored_key = single_byte_xor(given_input);
+
+  ASSERT_EQ(scored_key, given_key);
+}

--- a/test/test_01_03_single_byte_xor.cpp
+++ b/test/test_01_03_single_byte_xor.cpp
@@ -3,11 +3,11 @@
 #include "01_03_single_byte_xor.hpp"
 
 TEST(single_byte_xor, given_example) {
-  const std::string given_input =
-      "1b37373331363f78151b7f2b783431333d78397828372d363c78373e783a393b3736";
-  char given_key = '0';
+    const std::string given_input =
+        "1b37373331363f78151b7f2b783431333d78397828372d363c78373e783a393b3736";
+    char given_key = 'x';
 
-  char scored_key = single_byte_xor(given_input);
+    char scored_key = single_byte_xor(given_input);
 
-  ASSERT_EQ(scored_key, given_key);
+    ASSERT_EQ(scored_key, given_key);
 }


### PR DESCRIPTION
There are 8 challenges in [Crypto Challenge Set 1](https://cryptopals.com/sets/1). This branch and PR includes notes and solutions for challenge 3.

During debugging, there appeared to be issues with the `string_interaction` function `hex_from_string`. Changes were made to use the default signed `char` instead of `uint8_t` due to the use of XOR on ASCII characters in this challenge. The runtime of `single_byte_xor` does incur additional string copies as maxes are found, but this challenge is relatively small and does not require further optimization.

Standardized formatting with  `.clang-format` using Google's style with an indent of 4 spaces.